### PR TITLE
Fix armv7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3-alpine
+FROM python:3-slim
 LABEL maintainer="Stephan Fudeus <github@mails.fudeus.net>"
 
-RUN apk update && apk add git
-RUN pip3 install -U git+https://github.com/svalouch/rctmon
+#RUN apk update && apk add git cargo
+RUN apt-get update && apt-get -y --no-install-recommends install git
+RUN pip3 install -U --no-cache-dir git+https://github.com/svalouch/rctmon
 
 CMD ["rctmon", "-c", "/config.yaml", "daemon"]
 EXPOSE 9831

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a multi-arch docker build of [svalouch/rctmon](https://github.com/svalou
 
 ## Usage
 
-This project auto-publishes a multi-arch (armv7, am64, amd64) docker image to [Docker Hub](https://hub.docker.com/r/sfudeus/rctmon).
+This project auto-publishes a multi-arch (armv7, arm64, amd64) docker image to [Docker Hub](https://hub.docker.com/r/sfudeus/rctmon).
 The exporter runs on port 9831 by default (exposed port in `Dockerfile`, but can be configured to run on a different port.
 
 It can be run with the following command,


### PR DESCRIPTION
Switch to debian-slim base images instead of alpine because of new expensive rust dependency. 

Adding cargo to alpine image would end up in 350M images, debian around 100M. 

fixes #6 